### PR TITLE
Explicitly declare blas

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -24,6 +24,7 @@ requirements:
     - swig>=3.0.7
   host:
     - gsl
+    - blas
     - zlib
     - fftw
     - hdf5
@@ -44,6 +45,7 @@ outputs:
       build:
         - {{ compiler('c') }}
       host:
+        - blas
         - gsl
         - zlib
         - fftw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - swig>=3.0.7
   host:
     - gsl
-    - blas
     - zlib
     - fftw
     - hdf5
@@ -51,6 +50,7 @@ outputs:
         - fftw
         - hdf5
       run:
+        - blas
         - gsl
         - zlib
         - fftw


### PR DESCRIPTION
This patches meta.yaml to explicitly declare `blas` as a host dependency in the hope that this fixes linking issue.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
