### PR TITLE
Use activate_in_script to include build_env in output scripts

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -9,11 +9,11 @@ docker_image:
 gsl:
 - '2.2'
 hdf5:
-- 1.10.2
+- 1.10.3
 numpy:
 - '1.9'
 openblas:
-- 0.2.20
+- 0.3.3
 pin_run_as_build:
   gsl:
     max_pin: x.x
@@ -28,7 +28,6 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
-- '3.5'
 - '3.6'
 zlib:
 - '1.2'

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -9,7 +9,7 @@ channel_targets:
 gsl:
 - '2.2'
 hdf5:
-- 1.10.2
+- 1.10.3
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
@@ -17,7 +17,7 @@ macos_min_version:
 numpy:
 - '1.9'
 openblas:
-- 0.2.20
+- 0.3.3
 pin_run_as_build:
   gsl:
     max_pin: x.x
@@ -32,7 +32,6 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - '2.7'
-- '3.5'
 - '3.6'
 zlib:
 - '1.2'

--- a/recipe/install-c.sh
+++ b/recipe/install-c.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 set -e
-
-source activate "${PREFIX}"
+pushd ${SRC_DIR}
 make install

--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 set -e
-
-. activate "${PREFIX}"
-
 pushd ${SRC_DIR}
 
 # configure only python bindings and pure-python extras

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:
@@ -33,10 +33,14 @@ requirements:
 outputs:
   - name: lal
     script: install-c.sh
+    build:
+      activate_in_script: True
     requirements:
-      host:
+      build:
         - {{ compiler('c') }}
+        - pkg-config
         - make
+      host:
         - swig >=3.0.7
         - blas 1.1 openblas
         - openblas
@@ -69,11 +73,14 @@ outputs:
         needed to run applications that use the LAL library.
   - name: python-lal
     script: install-python.sh
+    build:
+      activate_in_script: True
     requirements:
-      host:
+      build:
         - {{ compiler('c') }}
         - make
         - pkg-config
+      host:
         - swig >=3.0.7
         - {{ pin_subpackage('lal', exact=True) }}
         - python


### PR DESCRIPTION
This PR modifies the recipe to use the

```yaml
    build:
      activate_in_script: True
```

option, activating the `_build_env` during the output scripts, meaning we can cleanly separate the `build` and `host` requirements for each sub-package, rather than forcing them all into `host`.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
