### PR TITLE
Added run_exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Feedstock license: BSD 3-Clause
 Summary: LSC Algorithm Library
 
 The LSC Algorithm Library for gravitational wave data analysis.
-This package contains the shared-object libraries and python bindings
-needed to run applications that use the LAL library.
+This package contains the shared-object libraries needed to run
+applications that use the LAL library.  If you want to install
+the Python bindings, please install the associated python-lal
+package.
 
 
 Current build status

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -44,6 +44,9 @@ test:
 
 outputs:
   - name: lal
+    build:
+      run_exports:
+        - {{ pin_subpackage("lal", max_pin="x.x") }}
 
   - name: python-lal
     script: install-python.sh


### PR DESCRIPTION
This PR adds `run_exports` to the C library, so that downstream packages that build against `lal` are pinned to compatible versions.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
