### PR TITLE
Update run_exports

### DIFF
--- a/.ci_support/linux_fft_implfftw.yaml
+++ b/.ci_support/linux_fft_implfftw.yaml
@@ -34,5 +34,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+python_impl:
+- cpython
 zlib:
 - '1.2'

--- a/.ci_support/linux_fft_implmkl.yaml
+++ b/.ci_support/linux_fft_implmkl.yaml
@@ -34,5 +34,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+python_impl:
+- cpython
 zlib:
 - '1.2'

--- a/.ci_support/osx_fft_implfftw.yaml
+++ b/.ci_support/osx_fft_implfftw.yaml
@@ -38,5 +38,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+python_impl:
+- cpython
 zlib:
 - '1.2'

--- a/.ci_support/osx_fft_implmkl.yaml
+++ b/.ci_support/osx_fft_implmkl.yaml
@@ -38,5 +38,7 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+python_impl:
+- cpython
 zlib:
 - '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "2dddf32cb84a5124381f114ee35f017538e6748827fd7c3eab8f69cc685f5b12" %}
 
 # define build number
-{% set build = 0 %}
+{% set build = 1 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}
@@ -64,7 +64,7 @@ outputs:
   - name: lal
     build:
       run_exports:
-        - {{ pin_subpackage("lal", max_pin="x.x") }}
+        - {{ pin_subpackage("lal", max_pin="x") }}
 
   - name: python-lal
     script: install-python.sh


### PR DESCRIPTION
This PR updates the `run_exports` declaration, since upstream now uses the major version number to signal backwards incompatibility.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
