### PR TITLE
Fix overlinking in SWIG python library

### DIFF
--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -33,9 +33,13 @@ ${SRC_DIR}/configure \
 	${FFT_CONFIG_ARGS} \
 ;
 
+# patch out dependency_libs from libtool archive to prevent overlinking
+sed -i '/^dependency_libs/d' lib/liblal.la
+sed -i '/^dependency_libs/d' lib/support/liblalsupport.la
+
 # build
-make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig
-make -j ${CPU_COUNT} V=1 VERBOSE=1 -C python
+make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig LIBS=""
+make -j ${CPU_COUNT} V=1 VERBOSE=1 -C python LIBS=""
 
 # install
 make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig install-exec  # swig bindings

--- a/recipe/install-python.sh
+++ b/recipe/install-python.sh
@@ -34,8 +34,8 @@ ${SRC_DIR}/configure \
 ;
 
 # patch out dependency_libs from libtool archive to prevent overlinking
-sed -i '/^dependency_libs/d' lib/liblal.la
-sed -i '/^dependency_libs/d' lib/support/liblalsupport.la
+sed -i.tmp '/^dependency_libs/d' lib/liblal.la
+sed -i.tmp '/^dependency_libs/d' lib/support/liblalsupport.la
 
 # build
 make -j ${CPU_COUNT} V=1 VERBOSE=1 -C swig LIBS=""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "97905d5da27c62c7e153db49825e23cafd53fd295659313829dd6110d820b316" %}
 
 # define build number
-{% set build = 0 %}
+{% set build = 1 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}
@@ -105,29 +105,24 @@ outputs:
         - pkg-config >=0.18.0
         - swig >={{ swig_version }}
       host:
-        - gsl
         - {{ pin_subpackage('liblal', exact=True) }}
-        - mkl-devel {{ mkl }}  # [fft_impl == "mkl"]
         - numpy
         - python
+        # this is here in case the solver gets confused during conda-build
+        - mkl {{ mkl }}  # [fft_impl == "mkl"]
       run:
         # NOTE: on linux, python-lal links the LAL dependencies
         #       as well so we have to list them here. why this
         #       doesn't happen on osx, I'm not sure.
-        - fftw  # [linux and fft_impl == "fftw"]
-        - gsl
-        - hdf5  # [linux]
         - {{ pin_subpackage('liblal', exact=True) }}
         - ligo-segments
         - lscsoft-glue >=1.54.1
-        - mkl  # [fft_impl == "mkl"]
         - {{ pin_compatible('numpy') }}
         - python
         - python-dateutil
         - python-ligo-lw
         - scipy
         - six
-        - zlib  # [linux]
     test:
       requires:
         - freezegun

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,7 +130,7 @@ outputs:
       source_files:
         - test/python
       commands:
-        - python -m pytest -rs -v --junit-xml=junit.xml test/python
+        - python -m pytest -rs -v test/python
       imports:
         - lal
         - lal.antenna

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,7 @@ outputs:
     script: install-python.sh
     build:
       ignore_run_exports:
+        - mkl
         # ignore run_exports from python's recipe
         - python
       string: {{ fft_impl }}_py{{ py }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
@@ -106,10 +107,9 @@ outputs:
         - swig >={{ swig_version }}
       host:
         - {{ pin_subpackage('liblal', exact=True) }}
+        - mkl-devel {{ mkl }}  # [fft_impl == "mkl"]
         - numpy
         - python
-        # this is here in case the solver gets confused during conda-build
-        - mkl {{ mkl }}  # [fft_impl == "mkl"]
       run:
         # NOTE: on linux, python-lal links the LAL dependencies
         #       as well so we have to list them here. why this


### PR DESCRIPTION
This PR fixes the annoying overlinking issues in the SWIG python library.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
