### PR TITLE
pin runtime numpy to <1.20.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "97905d5da27c62c7e153db49825e23cafd53fd295659313829dd6110d820b316" %}
 
 # define build number
-{% set build = 1 %}
+{% set build = 2 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}
@@ -15,7 +15,6 @@
 
 # dependency versions
 {% set swig_version = "3.0.10" %}
-{% set numpy_version = "1.7" %}
 
 package:
   name: {{ name }}-split
@@ -118,6 +117,8 @@ outputs:
         - ligo-segments
         - lscsoft-glue >=1.54.1
         - {{ pin_compatible('numpy') }}
+        # swig bindings cause segmentation fault
+        - numpy <1.20.0a0
         - python
         - python-dateutil
         - python-ligo-lw


### PR DESCRIPTION
See https://git.ligo.org/lscsoft/lalsuite/-/issues/414.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
