### PR TITLE
Remove python-ligo-lw requirement for osx and arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "8f83b419d7a824971dda95f2c493682c129a75127a87f0c9cec06af943693393" %}
 
 # define build number
-{% set build = 0 %}
+{% set build = 1 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}
@@ -141,7 +141,7 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - python
         - python-dateutil
-        - python-ligo-lw
+        - python-ligo-lw  # [not (osx and arm64)]
         - scipy
         - six
     test:


### PR DESCRIPTION
This PR removes a circular runtime requirement between this package and `python-ligo-lw`, so that hopefully the osx-arm64 migration might actually occur for this package.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
