### PR TITLE
Rebuild for hdf51121 on osx-arm64

### DIFF
--- a/.ci_support/linux_64_fft_implfftw.yaml
+++ b/.ci_support/linux_64_fft_implfftw.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -25,6 +25,8 @@ numpy:
 - '1.18'
 - '1.18'
 - '1.19'
+openssl:
+- 1.1.1
 pin_run_as_build:
   fftw:
     max_pin: x

--- a/.ci_support/linux_64_fft_implmkl.yaml
+++ b/.ci_support/linux_64_fft_implmkl.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:
@@ -25,6 +25,8 @@ numpy:
 - '1.18'
 - '1.18'
 - '1.19'
+openssl:
+- 1.1.1
 pin_run_as_build:
   fftw:
     max_pin: x

--- a/.ci_support/osx_64_fft_implfftw.yaml
+++ b/.ci_support/osx_64_fft_implfftw.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fft_impl:
@@ -25,6 +25,8 @@ numpy:
 - '1.18'
 - '1.18'
 - '1.19'
+openssl:
+- 1.1.1
 pin_run_as_build:
   fftw:
     max_pin: x

--- a/.ci_support/osx_64_fft_implmkl.yaml
+++ b/.ci_support/osx_64_fft_implmkl.yaml
@@ -5,7 +5,7 @@ c_compiler:
 c_compiler_version:
 - '11'
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 fft_impl:
@@ -25,6 +25,8 @@ numpy:
 - '1.18'
 - '1.18'
 - '1.19'
+openssl:
+- 1.1.1
 pin_run_as_build:
   fftw:
     max_pin: x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -23,6 +23,8 @@ mkl:
 numpy:
 - '1.19'
 - '1.19'
+openssl:
+- 1.1.1
 pin_run_as_build:
   fftw:
     max_pin: x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -15,7 +15,7 @@ fftw:
 gsl:
 - '2.7'
 hdf5:
-- 1.10.6
+- 1.12.1
 macos_machine:
 - arm64-apple-darwin20.0.0
 mkl:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -121,8 +121,10 @@ outputs:
     script: install-python.sh
     build:
       ignore_run_exports:
+        # things we declare to help the solver, but don't actually need
         - mkl
-        # ignore run_exports from python's recipe
+        - openssl
+        # we don't link directly against libpython
         - python
       string: {{ fft_impl }}_py{{ py }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
     requirements:
@@ -137,9 +139,11 @@ outputs:
         - python                              # [build_platform != target_platform]
       host:
         - {{ pin_subpackage('liblal', exact=True) }}
-        - mkl-devel {{ mkl }}  # [fft_impl == "mkl"]
         - numpy
         - python
+        # extras to help the solver:
+        - mkl-devel {{ mkl }}  # [fft_impl == "mkl"]
+        - openssl
       run:
         # NOTE: on linux, python-lal links the LAL dependencies
         #       as well so we have to list them here. why this
@@ -189,6 +193,10 @@ outputs:
     script: install-bin.sh
     build:
       ignore_run_exports:
+        # things we declare to help the solver, but don't actually need
+        - mkl
+        - openssl
+        # we don't link directly against libpython
         - python
       string: {{ fft_impl }}_py{{ py }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
     requirements:
@@ -199,9 +207,10 @@ outputs:
         - sed
       host:
         - {{ pin_subpackage('liblal', exact=True) }}
-        # this is here in case the solver gets confused during conda-build
-        - mkl {{ mkl }}  # [fft_impl == "mkl"]
         - python
+        # extras to help the solver:
+        - mkl {{ mkl }}  # [fft_impl == "mkl"]
+        - openssl
       run:
         - {{ pin_subpackage('liblal', exact=True) }}
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "8f83b419d7a824971dda95f2c493682c129a75127a87f0c9cec06af943693393" %}
 
 # define build number
-{% set build = 1 %}
+{% set build = 2 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}


### PR DESCRIPTION
This PR fixes a rendering issue whereby osx-arm64 (#61) wasn't included in #58.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
