### PR TITLE
Remove python-ligo-lw runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "8f83b419d7a824971dda95f2c493682c129a75127a87f0c9cec06af943693393" %}
 
 # define build number
-{% set build = 2 %}
+{% set build = 3 %}
 
 # default FFT implememntation to FFTW
 {% set fft_impl = fft_impl or 'fftw' %}
@@ -153,7 +153,6 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - python
         - python-dateutil
-        - python-ligo-lw  # [not (osx and arm64)]
         - scipy
         - six
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -159,17 +159,18 @@ outputs:
       requires:
         - freezegun
         - lscsoft-glue  # [x86_64]
-        - pytest >=4.0.0a0
+        - pytest >=4.0
+        - python-ligo-lw  # [x86_64]
       source_files:
         - test/python
       commands:
-        - python -m pytest -ra -v test/python
+        - python -m pytest -ra -v test/python  # [x86_64]
       imports:
         - lal
         - lal.antenna
         - lal.gpstime
-        - lal.rate
-        - lal.series
+        - lal.rate  # [x86_64]
+        - lal.series  # [x86_64]
         - lal.utils
     about:
       home: https://wiki.ligo.org/Computing/LALSuite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -158,7 +158,7 @@ outputs:
     test:
       requires:
         - freezegun
-        - lscsoft-glue
+        - lscsoft-glue  # [x86_64]
         - pytest >=4.0.0a0
       source_files:
         - test/python


### PR DESCRIPTION
This PR removes the (circular) runtime requirement on `python-ligo-lw`. It makes migrating to new platforms very inconvenient - any users that actually need that part of the code know what they are doing.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
