### PR TITLE
Add hdf5 host requirement to Python packages to create unique pins for each HDF5 build

### DIFF
--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ chmod +x "${micromamba_exe}"
 echo "Creating environment"
 "${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
   --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1" "py-lief!=0.15.1"
+  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
 mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
 echo "Cleaning up micromamba"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "7.6.0" %}
 
 # define build number
-{% set build = 2 %}
+{% set build = 3 %}
 
 # default FFT implememntation to FFTW
 {% if fft_impl is not defined %}
@@ -133,7 +133,17 @@ outputs:
     script: build-python.sh
     build:
       error_overlinking: true
+      force_use_keys:
+        # force this package to use the same keys as liblal so that
+        # we ensure a unique python-lal build string for each unique
+        # liblal build
+        - fftw  # [fft_impl == "fftw"]
+        - gsl
+        - hdf5
+        - mkl  # [fft_impl == "mkl"]
+        - zlib
       ignore_run_exports:
+        # needed by ./configure but not linked by python-lal
         - libzlib
         # things we declare to help the solver, but don't actually need
         - mkl  # [fft_impl == "mkl"]
@@ -200,6 +210,14 @@ outputs:
     script: install-bin.sh
     build:
       error_overlinking: true
+      force_use_keys:
+        # force this package to use the same keys as liblal so that
+        # we ensure a unique lal build string for each unique liblal build
+        - fftw  # [fft_impl == "fftw"]
+        - gsl
+        - hdf5
+        - mkl  # [fft_impl == "mkl"]
+        - zlib
       ignore_run_exports:
         # things we declare to help the solver, but don't actually need
         - mkl
@@ -218,7 +236,7 @@ outputs:
         - python
         - {{ pin_subpackage('python-lal', exact=True) }}
         # extras to help the solver:
-        - mkl {{ mkl }}  # [fft_impl == "mkl"]
+        - mkl-devel {{ mkl }}  # [fft_impl == "mkl"]
       run:
         - fftw  # [fft_impl == "fftw"]
         - {{ pin_subpackage('liblal', exact=True) }}


### PR DESCRIPTION
The current migration with multiple HDF5 pins means that there are two different `liblal` packages with unique build strings, but the downstream packages (`python-lal` and `lal`) don't use `hdf5` for the build string, so _aren't_ unique.

This PR adds [`force_use_keys`](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#build-number-and-string) to the `build` section for each of the downstream outputs (`python-lal` and `lal`) to ensure that the build string for those outputs uses the same 'uniqueness conditions' as `liblal`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
